### PR TITLE
Upgrade react-uploader (fixes TTLs for partially failed uploads)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "restorephotos",
+  "name": "restorePhotos",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
@@ -15,10 +15,10 @@
         "react-compare-slider": "^2.2.0",
         "react-countup": "^6.4.0",
         "react-dom": "18.2.0",
-        "react-uploader": "^3.0.2",
+        "react-uploader": "^3.3.0",
         "react-use-measure": "^2.1.1",
         "request-ip": "^3.3.0",
-        "uploader": "^3.0.2"
+        "uploader": "^3.3.0"
       },
       "devDependencies": {
         "@types/node": "18.11.3",
@@ -820,9 +820,9 @@
       "dev": true
     },
     "node_modules/@upload-io/upload-api-client-upload-js": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@upload-io/upload-api-client-upload-js/-/upload-api-client-upload-js-2.10.0.tgz",
-      "integrity": "sha512-F73xyglCCVX4drTkDt/B2kgB1nubArVx8O2rau6SDqDGM8Uf0iucXjoP4LPbSJXdCM8hP6uM5EEhuqUoqNneXA=="
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@upload-io/upload-api-client-upload-js/-/upload-api-client-upload-js-2.14.0.tgz",
+      "integrity": "sha512-mlEqPNhnZQh87EPuYAEPjeRtbg8LaaK2ronwDQomYmc9HGLU4pEBy20JJlIQ4wbfc9v5P7oskS87zRL3gIwVsg=="
     },
     "node_modules/@upstash/ratelimit": {
       "version": "0.1.5",
@@ -1833,9 +1833,9 @@
       }
     },
     "node_modules/progress-smoother": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/progress-smoother/-/progress-smoother-1.3.0.tgz",
-      "integrity": "sha512-vWtKd8Q1pQXHJ6Fx4pa5fbSCj+p6BPKfWufCVmagOjNKc3JsNsMfgTF55yx8UE0mNnZlnbKHr20+M/imHsnNbQ=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/progress-smoother/-/progress-smoother-1.4.0.tgz",
+      "integrity": "sha512-ctIG/KF/3DQ1zQHMWbXjcnicggTsEzZEA2JEnJNrPtK88tmqN9cfQf01yfLWGCBF93R5XN1EUe/z/IV5NKrmCw=="
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -1914,11 +1914,11 @@
       }
     },
     "node_modules/react-uploader": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/react-uploader/-/react-uploader-3.0.2.tgz",
-      "integrity": "sha512-2O2PNZuzzlO32FNZk5beNEm8D+R9mbfkk2Mlp5Z0HBQpk6IjyR4QknK2xwAtFM21u9l7i8Msr6xUyfajcuJ+Rg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/react-uploader/-/react-uploader-3.3.0.tgz",
+      "integrity": "sha512-oi+AUWBE4+uRJlLCOTQ7RZijY6HhajbdAxWq6FG1RqMeEiNelXgrVqPtpsZquaMBg+yIBMq2B6H3Yi9oW8u1Xw==",
       "dependencies": {
-        "uploader": "^3.0.0"
+        "uploader": "^3.3.0"
       },
       "peerDependencies": {
         "react": ">=16.3.0"
@@ -2193,22 +2193,22 @@
       }
     },
     "node_modules/upload-js": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/upload-js/-/upload-js-2.4.1.tgz",
-      "integrity": "sha512-3y7wEYr5GHRXiuPnyX8jb++7j3wW0AG3jbWwwKErWIW1Z9yvjM55ATI1sgz+RciOmnRomfNktNi3BIJ8E5se6g==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/upload-js/-/upload-js-2.8.0.tgz",
+      "integrity": "sha512-an/f11ilO8W4XKkhapywE9uBIV75TZefdHYF6k0P9gCCu2KB8z9pRO64I4JpNfR0wJmTx1wb1uynK8NEHo6+Fg==",
       "dependencies": {
-        "@upload-io/upload-api-client-upload-js": "^2.10.0",
-        "progress-smoother": "^1.3.0"
+        "@upload-io/upload-api-client-upload-js": "^2.14.0",
+        "progress-smoother": "^1.4.0"
       }
     },
     "node_modules/uploader": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/uploader/-/uploader-3.0.2.tgz",
-      "integrity": "sha512-KNHnlNRgYdsygTY796AlheapE4lE4Q6HdRQ+KfB2efETx2YjSvWhvymYtV55sBqlrdOxjG+aj9Muoowg+2lulg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/uploader/-/uploader-3.3.0.tgz",
+      "integrity": "sha512-Px1AMX8FKPB2aBdBejZQEUksn9djaG69skjl0ue0VkuF+R9/pLQ8ltFKhIMTphY6MmmIi03jezNIsxW9P2h8/Q==",
       "dependencies": {
         "classnames": "^2.2.6",
         "preact": "^10.6.5",
-        "upload-js": "^2.4.0"
+        "upload-js": "^2.8.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -2805,9 +2805,9 @@
       "dev": true
     },
     "@upload-io/upload-api-client-upload-js": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@upload-io/upload-api-client-upload-js/-/upload-api-client-upload-js-2.10.0.tgz",
-      "integrity": "sha512-F73xyglCCVX4drTkDt/B2kgB1nubArVx8O2rau6SDqDGM8Uf0iucXjoP4LPbSJXdCM8hP6uM5EEhuqUoqNneXA=="
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@upload-io/upload-api-client-upload-js/-/upload-api-client-upload-js-2.14.0.tgz",
+      "integrity": "sha512-mlEqPNhnZQh87EPuYAEPjeRtbg8LaaK2ronwDQomYmc9HGLU4pEBy20JJlIQ4wbfc9v5P7oskS87zRL3gIwVsg=="
     },
     "@upstash/ratelimit": {
       "version": "0.1.5",
@@ -3482,9 +3482,9 @@
       "integrity": "sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg=="
     },
     "progress-smoother": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/progress-smoother/-/progress-smoother-1.3.0.tgz",
-      "integrity": "sha512-vWtKd8Q1pQXHJ6Fx4pa5fbSCj+p6BPKfWufCVmagOjNKc3JsNsMfgTF55yx8UE0mNnZlnbKHr20+M/imHsnNbQ=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/progress-smoother/-/progress-smoother-1.4.0.tgz",
+      "integrity": "sha512-ctIG/KF/3DQ1zQHMWbXjcnicggTsEzZEA2JEnJNrPtK88tmqN9cfQf01yfLWGCBF93R5XN1EUe/z/IV5NKrmCw=="
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -3531,11 +3531,11 @@
       }
     },
     "react-uploader": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/react-uploader/-/react-uploader-3.0.2.tgz",
-      "integrity": "sha512-2O2PNZuzzlO32FNZk5beNEm8D+R9mbfkk2Mlp5Z0HBQpk6IjyR4QknK2xwAtFM21u9l7i8Msr6xUyfajcuJ+Rg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/react-uploader/-/react-uploader-3.3.0.tgz",
+      "integrity": "sha512-oi+AUWBE4+uRJlLCOTQ7RZijY6HhajbdAxWq6FG1RqMeEiNelXgrVqPtpsZquaMBg+yIBMq2B6H3Yi9oW8u1Xw==",
       "requires": {
-        "uploader": "^3.0.0"
+        "uploader": "^3.3.0"
       }
     },
     "react-use-measure": {
@@ -3708,22 +3708,22 @@
       }
     },
     "upload-js": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/upload-js/-/upload-js-2.4.1.tgz",
-      "integrity": "sha512-3y7wEYr5GHRXiuPnyX8jb++7j3wW0AG3jbWwwKErWIW1Z9yvjM55ATI1sgz+RciOmnRomfNktNi3BIJ8E5se6g==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/upload-js/-/upload-js-2.8.0.tgz",
+      "integrity": "sha512-an/f11ilO8W4XKkhapywE9uBIV75TZefdHYF6k0P9gCCu2KB8z9pRO64I4JpNfR0wJmTx1wb1uynK8NEHo6+Fg==",
       "requires": {
-        "@upload-io/upload-api-client-upload-js": "^2.10.0",
-        "progress-smoother": "^1.3.0"
+        "@upload-io/upload-api-client-upload-js": "^2.14.0",
+        "progress-smoother": "^1.4.0"
       }
     },
     "uploader": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/uploader/-/uploader-3.0.2.tgz",
-      "integrity": "sha512-KNHnlNRgYdsygTY796AlheapE4lE4Q6HdRQ+KfB2efETx2YjSvWhvymYtV55sBqlrdOxjG+aj9Muoowg+2lulg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/uploader/-/uploader-3.3.0.tgz",
+      "integrity": "sha512-Px1AMX8FKPB2aBdBejZQEUksn9djaG69skjl0ue0VkuF+R9/pLQ8ltFKhIMTphY6MmmIi03jezNIsxW9P2h8/Q==",
       "requires": {
         "classnames": "^2.2.6",
         "preact": "^10.6.5",
-        "upload-js": "^2.4.0"
+        "upload-js": "^2.8.0"
       }
     },
     "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
     "react-compare-slider": "^2.2.0",
     "react-countup": "^6.4.0",
     "react-dom": "18.2.0",
-    "react-uploader": "^3.0.2",
+    "react-uploader": "^3.3.0",
     "react-use-measure": "^2.1.1",
     "request-ip": "^3.3.0",
-    "uploader": "^3.0.2"
+    "uploader": "^3.3.0"
   },
   "devDependencies": {
     "@types/node": "18.11.3",


### PR DESCRIPTION
Hi @Nutlope 👋 

We have upgraded to `react-uploader@3.3.0` in this PR.

This includes a fix for [Upload.io](https://upload.io/) file TTLs (file expirations) for uploads that have partially succeeded.

Hope this helps!