### PR TITLE
fix link to youtube video

### DIFF
--- a/pages/restore.tsx
+++ b/pages/restore.tsx
@@ -83,7 +83,7 @@ const Home: NextPage = () => {
       <Header />
       <main className="flex flex-1 w-full flex-col items-center justify-center text-center px-4 mt-4 sm:mb-0 mb-8">
         <a
-          href="https://youtu.be/JcE-1xzQTE0"
+          href="https://youtu.be/FRQtFDDrUXQ"
           target="_blank"
           rel="noreferrer"
           className="border rounded-2xl py-1 px-4 text-slate-500 text-sm mb-5 hover:scale-105 transition duration-300 ease-in-out"


### PR DESCRIPTION
I think this is currently linking to the wrong video:

<img width="643" alt="Screenshot 2023-01-30 at 1 33 46 PM" src="https://user-images.githubusercontent.com/2289/215601023-7090e182-a3e8-4bf4-b737-b9598652db70.png">

It should be linking to this, right? https://youtu.be/FRQtFDDrUXQ