### PR TITLE
chore: improve image selection ux

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "restorephotos",
+  "name": "restorePhotos",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
@@ -20,10 +20,10 @@
         "react-countup": "^6.4.0",
         "react-dom": "18.2.0",
         "react-loader-spinner": "^5.3.4",
-        "react-uploader": "^3.3.0",
+        "react-uploader": "^3.11.0",
         "react-use-measure": "^2.1.1",
         "swr": "^2.1.0",
-        "uploader": "^3.3.0"
+        "uploader": "^3.10.0"
       },
       "devDependencies": {
         "@types/node": "18.11.3",
@@ -1036,9 +1036,9 @@
       "integrity": "sha512-50GQhDVTq/herLMiqSQkdtRu+d5q/cWHn4VvKJtrj4DJAjo1MNkWYa2MA41BaBO1q1HgsUjuQvEOk0QHvlnAaQ=="
     },
     "node_modules/@upload-io/upload-api-client-upload-js": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@upload-io/upload-api-client-upload-js/-/upload-api-client-upload-js-2.14.0.tgz",
-      "integrity": "sha512-mlEqPNhnZQh87EPuYAEPjeRtbg8LaaK2ronwDQomYmc9HGLU4pEBy20JJlIQ4wbfc9v5P7oskS87zRL3gIwVsg=="
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/@upload-io/upload-api-client-upload-js/-/upload-api-client-upload-js-2.15.0.tgz",
+      "integrity": "sha512-UGqT4wxCDhTTKnTLvqtKCyPJSswA2z6/Z6/sMakWGdJBBuwCHcOyXgoWafbPILrgWp3oMMQjnTfwwMBmR0O54w=="
     },
     "node_modules/@upstash/core-analytics": {
       "version": "0.0.6",
@@ -2830,11 +2830,11 @@
       }
     },
     "node_modules/react-uploader": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/react-uploader/-/react-uploader-3.3.0.tgz",
-      "integrity": "sha512-oi+AUWBE4+uRJlLCOTQ7RZijY6HhajbdAxWq6FG1RqMeEiNelXgrVqPtpsZquaMBg+yIBMq2B6H3Yi9oW8u1Xw==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/react-uploader/-/react-uploader-3.11.0.tgz",
+      "integrity": "sha512-bs1ChzxM/BNGFb2cm5CzFwo7PnPQ6Rw8uFOOkILZh8MMS2jH5VMklZUWmjuTTitekKm1HQgGjuxjV8dKqriggw==",
       "dependencies": {
-        "uploader": "^3.3.0"
+        "uploader": "^3.10.0"
       },
       "peerDependencies": {
         "react": ">=16.3.0"
@@ -3370,22 +3370,22 @@
       }
     },
     "node_modules/upload-js": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/upload-js/-/upload-js-2.8.0.tgz",
-      "integrity": "sha512-an/f11ilO8W4XKkhapywE9uBIV75TZefdHYF6k0P9gCCu2KB8z9pRO64I4JpNfR0wJmTx1wb1uynK8NEHo6+Fg==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/upload-js/-/upload-js-2.11.2.tgz",
+      "integrity": "sha512-q6IkwFLA3kL1MbBMvzCbJC0EHjMgjJ399f5QH3Up5rkoVjYXZxTKRgyJQeRT1HpqPQ3gCJdvZuL/Cv1LjBRGMg==",
       "dependencies": {
-        "@upload-io/upload-api-client-upload-js": "^2.14.0",
+        "@upload-io/upload-api-client-upload-js": "^2.15.0",
         "progress-smoother": "^1.4.0"
       }
     },
     "node_modules/uploader": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/uploader/-/uploader-3.3.0.tgz",
-      "integrity": "sha512-Px1AMX8FKPB2aBdBejZQEUksn9djaG69skjl0ue0VkuF+R9/pLQ8ltFKhIMTphY6MmmIi03jezNIsxW9P2h8/Q==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/uploader/-/uploader-3.10.0.tgz",
+      "integrity": "sha512-nGP2Ngf6/UdeGMRcuaPbFoLTQuPl+wrBQi8OwWIt169GvdX1+ztMJageVDw+5mXzWRGN2SyjkWXDr6onglURxg==",
       "dependencies": {
         "classnames": "^2.2.6",
         "preact": "^10.6.5",
-        "upload-js": "^2.8.0"
+        "upload-js": "^2.11.0"
       }
     },
     "node_modules/uri-js": {
@@ -4239,9 +4239,9 @@
       "integrity": "sha512-50GQhDVTq/herLMiqSQkdtRu+d5q/cWHn4VvKJtrj4DJAjo1MNkWYa2MA41BaBO1q1HgsUjuQvEOk0QHvlnAaQ=="
     },
     "@upload-io/upload-api-client-upload-js": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@upload-io/upload-api-client-upload-js/-/upload-api-client-upload-js-2.14.0.tgz",
-      "integrity": "sha512-mlEqPNhnZQh87EPuYAEPjeRtbg8LaaK2ronwDQomYmc9HGLU4pEBy20JJlIQ4wbfc9v5P7oskS87zRL3gIwVsg=="
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/@upload-io/upload-api-client-upload-js/-/upload-api-client-upload-js-2.15.0.tgz",
+      "integrity": "sha512-UGqT4wxCDhTTKnTLvqtKCyPJSswA2z6/Z6/sMakWGdJBBuwCHcOyXgoWafbPILrgWp3oMMQjnTfwwMBmR0O54w=="
     },
     "@upstash/core-analytics": {
       "version": "0.0.6",
@@ -5533,11 +5533,11 @@
       }
     },
     "react-uploader": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/react-uploader/-/react-uploader-3.3.0.tgz",
-      "integrity": "sha512-oi+AUWBE4+uRJlLCOTQ7RZijY6HhajbdAxWq6FG1RqMeEiNelXgrVqPtpsZquaMBg+yIBMq2B6H3Yi9oW8u1Xw==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/react-uploader/-/react-uploader-3.11.0.tgz",
+      "integrity": "sha512-bs1ChzxM/BNGFb2cm5CzFwo7PnPQ6Rw8uFOOkILZh8MMS2jH5VMklZUWmjuTTitekKm1HQgGjuxjV8dKqriggw==",
       "requires": {
-        "uploader": "^3.3.0"
+        "uploader": "^3.10.0"
       }
     },
     "react-use-measure": {
@@ -5915,22 +5915,22 @@
       }
     },
     "upload-js": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/upload-js/-/upload-js-2.8.0.tgz",
-      "integrity": "sha512-an/f11ilO8W4XKkhapywE9uBIV75TZefdHYF6k0P9gCCu2KB8z9pRO64I4JpNfR0wJmTx1wb1uynK8NEHo6+Fg==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/upload-js/-/upload-js-2.11.2.tgz",
+      "integrity": "sha512-q6IkwFLA3kL1MbBMvzCbJC0EHjMgjJ399f5QH3Up5rkoVjYXZxTKRgyJQeRT1HpqPQ3gCJdvZuL/Cv1LjBRGMg==",
       "requires": {
-        "@upload-io/upload-api-client-upload-js": "^2.14.0",
+        "@upload-io/upload-api-client-upload-js": "^2.15.0",
         "progress-smoother": "^1.4.0"
       }
     },
     "uploader": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/uploader/-/uploader-3.3.0.tgz",
-      "integrity": "sha512-Px1AMX8FKPB2aBdBejZQEUksn9djaG69skjl0ue0VkuF+R9/pLQ8ltFKhIMTphY6MmmIi03jezNIsxW9P2h8/Q==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/uploader/-/uploader-3.10.0.tgz",
+      "integrity": "sha512-nGP2Ngf6/UdeGMRcuaPbFoLTQuPl+wrBQi8OwWIt169GvdX1+ztMJageVDw+5mXzWRGN2SyjkWXDr6onglURxg==",
       "requires": {
         "classnames": "^2.2.6",
         "preact": "^10.6.5",
-        "upload-js": "^2.8.0"
+        "upload-js": "^2.11.0"
       }
     },
     "uri-js": {

--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
     "react-countup": "^6.4.0",
     "react-dom": "18.2.0",
     "react-loader-spinner": "^5.3.4",
-    "react-uploader": "^3.3.0",
+    "react-uploader": "^3.11.0",
     "react-use-measure": "^2.1.1",
     "swr": "^2.1.0",
-    "uploader": "^3.3.0"
+    "uploader": "^3.10.0"
   },
   "devDependencies": {
     "@types/node": "18.11.3",


### PR DESCRIPTION
Hey guys, 

I've been using restorePhotos for the past few weeks and it's worked well for me so far so good. One minor improvement to the UX would be to disable the selection of files that aren't allowed while uploading (e.g documents, pdfs or svgs). 

<img width="652" alt="Screenshot 2023-03-22 at 21 39 56" src="https://user-images.githubusercontent.com/45945474/227738155-7f7a4d8e-9592-49de-982a-c1b55c1939c2.png">

Currently, user is allowed to upload any file, before getting an error in the upload window. 

- I've fixed this by upgrading the versions of uploader & react-uploader. 

<img width="673" alt="Screenshot 2023-03-22 at 21 40 24" src="https://user-images.githubusercontent.com/45945474/227738208-01c2de2b-b1ec-4812-a195-e73d68a2ea59.png">



