### PR TITLE
Upgrade: react-uploader -> @bytescale/upload-widget-react

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,11 @@
 {
-  "name": "restorephotos",
+  "name": "restorePhotos",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "dependencies": {
+        "@bytescale/upload-widget-react": "^4.1.0",
         "@headlessui/react": "^1.7.7",
         "@next-auth/prisma-adapter": "^1.0.5",
         "@prisma/client": "^4.11.0",
@@ -20,10 +21,8 @@
         "react-countup": "^6.4.0",
         "react-dom": "18.2.0",
         "react-loader-spinner": "^5.3.4",
-        "react-uploader": "^3.3.0",
         "react-use-measure": "^2.1.1",
-        "swr": "^2.1.0",
-        "uploader": "^3.3.0"
+        "swr": "^2.1.0"
       },
       "devDependencies": {
         "@types/node": "18.11.3",
@@ -358,6 +357,33 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bytescale/sdk": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@bytescale/sdk/-/sdk-3.2.0.tgz",
+      "integrity": "sha512-8FqAPp1NCffd05aAvKY72A/8/hoVfhTW7nEMccSfngxGCfCnYJBwoZTv4/Qp5jh5XUVAN08vjNKI1LXTt1G1Xw=="
+    },
+    "node_modules/@bytescale/upload-widget": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@bytescale/upload-widget/-/upload-widget-4.7.0.tgz",
+      "integrity": "sha512-QiOYeDAlX4ZcweX0NXm3VSVYRumMdi5qjAEzrFXM4O7ps93Q4gzkT/8/Q9ybGxc+NVWQIew6OBQLweu83bfCOA==",
+      "dependencies": {
+        "@bytescale/sdk": "^3.2.0",
+        "classnames": "^2.2.6",
+        "preact": "^10.6.5"
+      }
+    },
+    "node_modules/@bytescale/upload-widget-react": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@bytescale/upload-widget-react/-/upload-widget-react-4.1.0.tgz",
+      "integrity": "sha512-cpz1nVIDwhbbSMnPJyURtT2QqpO55i0kqtO5Bx60AlX9MCaReXOqjn21unIInPxQqs0TxvglBPVCmTqUv4GviA==",
+      "dependencies": {
+        "@bytescale/upload-widget": "^4.6.0",
+        "lodash.isequal": "^4.5.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0"
       }
     },
     "node_modules/@emotion/stylis": {
@@ -1034,11 +1060,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/webgl2/-/webgl2-0.0.6.tgz",
       "integrity": "sha512-50GQhDVTq/herLMiqSQkdtRu+d5q/cWHn4VvKJtrj4DJAjo1MNkWYa2MA41BaBO1q1HgsUjuQvEOk0QHvlnAaQ=="
-    },
-    "node_modules/@upload-io/upload-api-client-upload-js": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@upload-io/upload-api-client-upload-js/-/upload-api-client-upload-js-2.14.0.tgz",
-      "integrity": "sha512-mlEqPNhnZQh87EPuYAEPjeRtbg8LaaK2ronwDQomYmc9HGLU4pEBy20JJlIQ4wbfc9v5P7oskS87zRL3gIwVsg=="
     },
     "node_modules/@upstash/core-analytics": {
       "version": "0.0.6",
@@ -2114,6 +2135,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
+    },
     "node_modules/long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
@@ -2708,11 +2734,6 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/progress-smoother": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/progress-smoother/-/progress-smoother-1.4.0.tgz",
-      "integrity": "sha512-ctIG/KF/3DQ1zQHMWbXjcnicggTsEzZEA2JEnJNrPtK88tmqN9cfQf01yfLWGCBF93R5XN1EUe/z/IV5NKrmCw=="
-    },
     "node_modules/psl": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
@@ -2827,17 +2848,6 @@
       "peerDependencies": {
         "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/react-uploader": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/react-uploader/-/react-uploader-3.3.0.tgz",
-      "integrity": "sha512-oi+AUWBE4+uRJlLCOTQ7RZijY6HhajbdAxWq6FG1RqMeEiNelXgrVqPtpsZquaMBg+yIBMq2B6H3Yi9oW8u1Xw==",
-      "dependencies": {
-        "uploader": "^3.3.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.3.0"
       }
     },
     "node_modules/react-use-measure": {
@@ -3369,25 +3379,6 @@
         "browserslist": ">= 4.21.0"
       }
     },
-    "node_modules/upload-js": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/upload-js/-/upload-js-2.8.0.tgz",
-      "integrity": "sha512-an/f11ilO8W4XKkhapywE9uBIV75TZefdHYF6k0P9gCCu2KB8z9pRO64I4JpNfR0wJmTx1wb1uynK8NEHo6+Fg==",
-      "dependencies": {
-        "@upload-io/upload-api-client-upload-js": "^2.14.0",
-        "progress-smoother": "^1.4.0"
-      }
-    },
-    "node_modules/uploader": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/uploader/-/uploader-3.3.0.tgz",
-      "integrity": "sha512-Px1AMX8FKPB2aBdBejZQEUksn9djaG69skjl0ue0VkuF+R9/pLQ8ltFKhIMTphY6MmmIi03jezNIsxW9P2h8/Q==",
-      "dependencies": {
-        "classnames": "^2.2.6",
-        "preact": "^10.6.5",
-        "upload-js": "^2.8.0"
-      }
-    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -3794,6 +3785,30 @@
         "@babel/helper-string-parser": "^7.19.4",
         "@babel/helper-validator-identifier": "^7.19.1",
         "to-fast-properties": "^2.0.0"
+      }
+    },
+    "@bytescale/sdk": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@bytescale/sdk/-/sdk-3.2.0.tgz",
+      "integrity": "sha512-8FqAPp1NCffd05aAvKY72A/8/hoVfhTW7nEMccSfngxGCfCnYJBwoZTv4/Qp5jh5XUVAN08vjNKI1LXTt1G1Xw=="
+    },
+    "@bytescale/upload-widget": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@bytescale/upload-widget/-/upload-widget-4.7.0.tgz",
+      "integrity": "sha512-QiOYeDAlX4ZcweX0NXm3VSVYRumMdi5qjAEzrFXM4O7ps93Q4gzkT/8/Q9ybGxc+NVWQIew6OBQLweu83bfCOA==",
+      "requires": {
+        "@bytescale/sdk": "^3.2.0",
+        "classnames": "^2.2.6",
+        "preact": "^10.6.5"
+      }
+    },
+    "@bytescale/upload-widget-react": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@bytescale/upload-widget-react/-/upload-widget-react-4.1.0.tgz",
+      "integrity": "sha512-cpz1nVIDwhbbSMnPJyURtT2QqpO55i0kqtO5Bx60AlX9MCaReXOqjn21unIInPxQqs0TxvglBPVCmTqUv4GviA==",
+      "requires": {
+        "@bytescale/upload-widget": "^4.6.0",
+        "lodash.isequal": "^4.5.0"
       }
     },
     "@emotion/stylis": {
@@ -4237,11 +4252,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/webgl2/-/webgl2-0.0.6.tgz",
       "integrity": "sha512-50GQhDVTq/herLMiqSQkdtRu+d5q/cWHn4VvKJtrj4DJAjo1MNkWYa2MA41BaBO1q1HgsUjuQvEOk0QHvlnAaQ=="
-    },
-    "@upload-io/upload-api-client-upload-js": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@upload-io/upload-api-client-upload-js/-/upload-api-client-upload-js-2.14.0.tgz",
-      "integrity": "sha512-mlEqPNhnZQh87EPuYAEPjeRtbg8LaaK2ronwDQomYmc9HGLU4pEBy20JJlIQ4wbfc9v5P7oskS87zRL3gIwVsg=="
     },
     "@upstash/core-analytics": {
       "version": "0.0.6",
@@ -5063,6 +5073,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
+    },
     "long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
@@ -5453,11 +5468,6 @@
         "@prisma/engines": "4.11.0"
       }
     },
-    "progress-smoother": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/progress-smoother/-/progress-smoother-1.4.0.tgz",
-      "integrity": "sha512-ctIG/KF/3DQ1zQHMWbXjcnicggTsEzZEA2JEnJNrPtK88tmqN9cfQf01yfLWGCBF93R5XN1EUe/z/IV5NKrmCw=="
-    },
     "psl": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
@@ -5530,14 +5540,6 @@
         "react-is": "^18.2.0",
         "styled-components": "^5.3.5",
         "styled-tools": "^1.7.2"
-      }
-    },
-    "react-uploader": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/react-uploader/-/react-uploader-3.3.0.tgz",
-      "integrity": "sha512-oi+AUWBE4+uRJlLCOTQ7RZijY6HhajbdAxWq6FG1RqMeEiNelXgrVqPtpsZquaMBg+yIBMq2B6H3Yi9oW8u1Xw==",
-      "requires": {
-        "uploader": "^3.3.0"
       }
     },
     "react-use-measure": {
@@ -5912,25 +5914,6 @@
       "requires": {
         "escalade": "^3.1.1",
         "picocolors": "^1.0.0"
-      }
-    },
-    "upload-js": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/upload-js/-/upload-js-2.8.0.tgz",
-      "integrity": "sha512-an/f11ilO8W4XKkhapywE9uBIV75TZefdHYF6k0P9gCCu2KB8z9pRO64I4JpNfR0wJmTx1wb1uynK8NEHo6+Fg==",
-      "requires": {
-        "@upload-io/upload-api-client-upload-js": "^2.14.0",
-        "progress-smoother": "^1.4.0"
-      }
-    },
-    "uploader": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/uploader/-/uploader-3.3.0.tgz",
-      "integrity": "sha512-Px1AMX8FKPB2aBdBejZQEUksn9djaG69skjl0ue0VkuF+R9/pLQ8ltFKhIMTphY6MmmIi03jezNIsxW9P2h8/Q==",
-      "requires": {
-        "classnames": "^2.2.6",
-        "preact": "^10.6.5",
-        "upload-js": "^2.8.0"
       }
     },
     "uri-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@bytescale/upload-widget-react": "^4.1.0",
+        "@bytescale/upload-widget-react": "^4.7.0",
         "@headlessui/react": "^1.7.7",
         "@next-auth/prisma-adapter": "^1.0.5",
         "@prisma/client": "^4.11.0",
@@ -360,14 +360,14 @@
       }
     },
     "node_modules/@bytescale/sdk": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@bytescale/sdk/-/sdk-3.2.0.tgz",
-      "integrity": "sha512-8FqAPp1NCffd05aAvKY72A/8/hoVfhTW7nEMccSfngxGCfCnYJBwoZTv4/Qp5jh5XUVAN08vjNKI1LXTt1G1Xw=="
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@bytescale/sdk/-/sdk-3.4.2.tgz",
+      "integrity": "sha512-yV72GRP/UjVSn2Cwytn/i5a4GV+Y+sZxplCgyvKSucBKHSaafc2QaM6oZi/o7iZvzmNBNJztN837btn+hRCfrw=="
     },
     "node_modules/@bytescale/upload-widget": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@bytescale/upload-widget/-/upload-widget-4.7.0.tgz",
-      "integrity": "sha512-QiOYeDAlX4ZcweX0NXm3VSVYRumMdi5qjAEzrFXM4O7ps93Q4gzkT/8/Q9ybGxc+NVWQIew6OBQLweu83bfCOA==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@bytescale/upload-widget/-/upload-widget-4.11.0.tgz",
+      "integrity": "sha512-pc7BT2udT90ZqWCp+09zo8rfzpX2HQQGPza8WMHty4/ZZu8FFnpikptABRM/F4v+cLWwQXIWO1zsq9rweYBtZw==",
       "dependencies": {
         "@bytescale/sdk": "^3.2.0",
         "classnames": "^2.2.6",
@@ -375,11 +375,11 @@
       }
     },
     "node_modules/@bytescale/upload-widget-react": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@bytescale/upload-widget-react/-/upload-widget-react-4.1.0.tgz",
-      "integrity": "sha512-cpz1nVIDwhbbSMnPJyURtT2QqpO55i0kqtO5Bx60AlX9MCaReXOqjn21unIInPxQqs0TxvglBPVCmTqUv4GviA==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@bytescale/upload-widget-react/-/upload-widget-react-4.7.0.tgz",
+      "integrity": "sha512-rI3Tvs/d6a3J3t0RYpGyykIAvzGk5tSuDSvnv/wxtsKt36YnGGBuXBFHxWOAIpmZZ/Jd8YMB8ZFDajC5It1vMg==",
       "dependencies": {
-        "@bytescale/upload-widget": "^4.6.0",
+        "@bytescale/upload-widget": "^4.11.0",
         "lodash.isequal": "^4.5.0"
       },
       "peerDependencies": {
@@ -3788,14 +3788,14 @@
       }
     },
     "@bytescale/sdk": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@bytescale/sdk/-/sdk-3.2.0.tgz",
-      "integrity": "sha512-8FqAPp1NCffd05aAvKY72A/8/hoVfhTW7nEMccSfngxGCfCnYJBwoZTv4/Qp5jh5XUVAN08vjNKI1LXTt1G1Xw=="
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@bytescale/sdk/-/sdk-3.4.2.tgz",
+      "integrity": "sha512-yV72GRP/UjVSn2Cwytn/i5a4GV+Y+sZxplCgyvKSucBKHSaafc2QaM6oZi/o7iZvzmNBNJztN837btn+hRCfrw=="
     },
     "@bytescale/upload-widget": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@bytescale/upload-widget/-/upload-widget-4.7.0.tgz",
-      "integrity": "sha512-QiOYeDAlX4ZcweX0NXm3VSVYRumMdi5qjAEzrFXM4O7ps93Q4gzkT/8/Q9ybGxc+NVWQIew6OBQLweu83bfCOA==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@bytescale/upload-widget/-/upload-widget-4.11.0.tgz",
+      "integrity": "sha512-pc7BT2udT90ZqWCp+09zo8rfzpX2HQQGPza8WMHty4/ZZu8FFnpikptABRM/F4v+cLWwQXIWO1zsq9rweYBtZw==",
       "requires": {
         "@bytescale/sdk": "^3.2.0",
         "classnames": "^2.2.6",
@@ -3803,11 +3803,11 @@
       }
     },
     "@bytescale/upload-widget-react": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@bytescale/upload-widget-react/-/upload-widget-react-4.1.0.tgz",
-      "integrity": "sha512-cpz1nVIDwhbbSMnPJyURtT2QqpO55i0kqtO5Bx60AlX9MCaReXOqjn21unIInPxQqs0TxvglBPVCmTqUv4GviA==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@bytescale/upload-widget-react/-/upload-widget-react-4.7.0.tgz",
+      "integrity": "sha512-rI3Tvs/d6a3J3t0RYpGyykIAvzGk5tSuDSvnv/wxtsKt36YnGGBuXBFHxWOAIpmZZ/Jd8YMB8ZFDajC5It1vMg==",
       "requires": {
-        "@bytescale/upload-widget": "^4.6.0",
+        "@bytescale/upload-widget": "^4.11.0",
         "lodash.isequal": "^4.5.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "prisma:generate": "prisma generate"
   },
   "dependencies": {
+    "@bytescale/upload-widget-react": "^4.1.0",
     "@headlessui/react": "^1.7.7",
     "@next-auth/prisma-adapter": "^1.0.5",
     "@prisma/client": "^4.11.0",
@@ -23,10 +24,8 @@
     "react-countup": "^6.4.0",
     "react-dom": "18.2.0",
     "react-loader-spinner": "^5.3.4",
-    "react-uploader": "^3.3.0",
     "react-use-measure": "^2.1.1",
-    "swr": "^2.1.0",
-    "uploader": "^3.3.0"
+    "swr": "^2.1.0"
   },
   "devDependencies": {
     "@types/node": "18.11.3",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "prisma:generate": "prisma generate"
   },
   "dependencies": {
-    "@bytescale/upload-widget-react": "^4.1.0",
+    "@bytescale/upload-widget-react": "^4.7.0",
     "@headlessui/react": "^1.7.7",
     "@next-auth/prisma-adapter": "^1.0.5",
     "@prisma/client": "^4.11.0",

--- a/pages/restore.tsx
+++ b/pages/restore.tsx
@@ -2,8 +2,9 @@ import { NextPage } from "next";
 import Head from "next/head";
 import Image from "next/image";
 import { useState } from "react";
+import { UrlBuilder } from "@bytescale/sdk";
+import { UploadWidgetConfig, UploadWidgetOnPreUploadResult } from "@bytescale/upload-widget";
 import { UploadDropzone } from "@bytescale/upload-widget-react";
-import { UploadWidgetConfig } from "@bytescale/upload-widget";
 import { CompareSlider } from "../components/CompareSlider";
 import Footer from "../components/Footer";
 import Header from "../components/Header";
@@ -16,8 +17,6 @@ import va from "@vercel/analytics";
 import { useSession, signIn } from "next-auth/react";
 import useSWR from "swr";
 import { Rings } from "react-loader-spinner";
-import {OnPreUploadResult} from "@bytescale/upload-widget/dist/config/OnPreUploadResult";
-import {UrlBuilder} from "@bytescale/sdk";
 
 const Home: NextPage = () => {
   const [originalPhoto, setOriginalPhoto] = useState<string | null>(null);
@@ -40,7 +39,7 @@ const Home: NextPage = () => {
     mimeTypes: ["image/jpeg", "image/png", "image/jpg"],
     editor: { images: { crop: false } },
     styles: { colors: { primary: "#000" } },
-    onPreUpload: async (file: File): Promise<OnPreUploadResult | undefined> => {
+    onPreUpload: async (file: File): Promise<UploadWidgetOnPreUploadResult | undefined> => {
       let isSafe = false;
       try {
         isSafe = await NSFWPredictor.isSafeImg(file);
@@ -61,12 +60,12 @@ const Home: NextPage = () => {
   const UploadDropZone = () => (
     <UploadDropzone
       options={options}
-      onUpdate={(files) => {
-        if (files.length !== 0) {
-          const image = files[0];
-          const imageName = image.originalFile.originalFileName
+      onUpdate={({ uploadedFiles }) => {
+        if (uploadedFiles.length !== 0) {
+          const image = uploadedFiles[0];
+          const imageName = image.originalFile.originalFileName;
           const imageUrl = UrlBuilder.url({
-            accountId: image.originalFile.accountId,
+            accountId: image.accountId,
             filePath: image.filePath,
             options: {
               transformation: "preset",

--- a/pages/restore.tsx
+++ b/pages/restore.tsx
@@ -17,6 +17,7 @@ import { useSession, signIn } from "next-auth/react";
 import useSWR from "swr";
 import { Rings } from "react-loader-spinner";
 import {OnPreUploadResult} from "@bytescale/upload-widget/dist/config/OnPreUploadResult";
+import {UrlBuilder} from "@bytescale/sdk";
 
 const Home: NextPage = () => {
   const [originalPhoto, setOriginalPhoto] = useState<string | null>(null);
@@ -60,11 +61,21 @@ const Home: NextPage = () => {
   const UploadDropZone = () => (
     <UploadDropzone
       options={options}
-      onUpdate={(file) => {
-        if (file.length !== 0) {
-          setPhotoName(file[0].originalFile.originalFileName);
-          setOriginalPhoto(file[0].fileUrl.replace("raw", "thumbnail"));
-          generatePhoto(file[0].fileUrl.replace("raw", "thumbnail"));
+      onUpdate={(files) => {
+        if (files.length !== 0) {
+          const image = files[0];
+          const imageName = image.originalFile.originalFileName
+          const imageUrl = UrlBuilder.url({
+            accountId: image.originalFile.accountId,
+            filePath: image.filePath,
+            options: {
+              transformation: "preset",
+              transformationPreset: "thumbnail"
+            }
+          });
+          setPhotoName(imageName);
+          setOriginalPhoto(imageUrl);
+          generatePhoto(imageUrl);
         }
       }}
       width="670px"


### PR DESCRIPTION
Hey @Nutlope 👋

We've renamed our packages and improved Bytescale's SDKs.

This PR includes the latest and greatest.

Changes in this PR:

- 👉 Migrate `react-uploader` -> `@bytescale/upload-widget-react` (see: [`MIGRATE.md`](https://github.com/bytescale/bytescale-upload-widget-react/blob/main/MIGRATE.md))
- 👉 Use `Bytescale.UrlBuilder` instead of `String.replace`.

Benefits:

- ✅  Simpler code (no more `Uploader` instance: it's all simply props on `UploadDropzone` now).
- ✅  Safer URL creation by using `UrlBuilder` (as `replace` could in theory modify the user's account ID in the URL).
- ✅  Better type hints re. URL parameter options, which come from the `UrlBuilder`.
- ✅  Better support for [Next.js edge runtimes](https://github.com/bytescale/bytescale-javascript-sdk/blob/main/package.json#L16-L19) in the core Bytescale JavaScript SDK.
- ✅  Support & bug fixes: `react-uploader` won't be receiving updates, whereas `@bytescale/upload-widget-react` will.